### PR TITLE
Feature/implement loop fusion

### DIFF
--- a/LoopFusion/FusionCandidate.cpp
+++ b/LoopFusion/FusionCandidate.cpp
@@ -5,29 +5,21 @@
 #include "FusionCandidate.h"
 #include "llvm/IR/BasicBlock.h"
 
-auto FusionCandidate::isCandidateForFusion() const -> bool { 
-    return hasSingleEntryPoint() && hasSingleExitPoint(); 
-}
-
-auto FusionCandidate::loop() const -> Loop* {
-    return L;
+auto FusionCandidate::isCandidateForFusion() const -> bool {
+  return hasSingleEntryPoint() && hasSingleExitPoint();
 }
 
 auto FusionCandidate::hasSingleEntryPoint() const -> bool {
-    
-    BasicBlock* LoopPredecessor = L->getLoopPredecessor();
 
-    return LoopPredecessor != nullptr;
+  BasicBlock *LoopPredecessor = L->getLoopPredecessor();
+
+  return LoopPredecessor != nullptr;
 }
 
 auto FusionCandidate::hasSingleExitPoint() const -> bool {
 
-    SmallVector<BasicBlock*> ExitBlocks{};
-    L->getExitBlocks(ExitBlocks);
+  SmallVector<BasicBlock *> ExitBlocks{};
+  L->getExitBlocks(ExitBlocks);
 
-    return ExitBlocks.size() == 1;
-}   
-
-Loop *FusionCandidate::getLoop() {
-    return L;
+  return ExitBlocks.size() == 1;
 }

--- a/LoopFusion/FusionCandidate.h
+++ b/LoopFusion/FusionCandidate.h
@@ -17,19 +17,17 @@ public:
 
   /// Checks if a loop is a candidate for a loop fusion.
   auto isCandidateForFusion() const -> bool;
-  auto loop() const -> Loop*;
 
-  Loop *getLoop();
-  inline BasicBlock *getPreheader() { return Preheader; };
-  inline BasicBlock *getHeader() { return Header; };
-  inline BasicBlock *getExitingBlock() { return ExitingBlock; };
-  inline BasicBlock *getLatch() { return Latch; };
+  inline auto getLoop() const -> Loop * { return L; };
+  inline auto getPreheader() const -> BasicBlock * { return Preheader; };
+  inline auto getHeader() const -> BasicBlock * { return Header; };
+  inline auto getExitingBlock() const -> BasicBlock * { return ExitingBlock; };
+  inline auto getLatch() const -> BasicBlock * { return Latch; };
 
 private:
-
   auto hasSingleEntryPoint() const -> bool;
   auto hasSingleExitPoint() const -> bool;
-  
+
   // Loop that represents a fusion candidate
   Loop *L;
   BasicBlock *Preheader;

--- a/LoopFusion/LoopFusion.cpp
+++ b/LoopFusion/LoopFusion.cpp
@@ -304,6 +304,10 @@ struct LoopFusion : public FunctionPass {
     }
 
     // Remove the original loops from the LLVM IR.
+    EliminateUnreachableBlocks(F);
+    LI.erase(L2->getLoop());
+
+    dbgs() << "Fusion done.\n";
   }
 
   void getAnalysisUsage(AnalysisUsage &AU) const override {

--- a/LoopFusion/LoopFusion.cpp
+++ b/LoopFusion/LoopFusion.cpp
@@ -314,6 +314,7 @@ struct LoopFusion : public FunctionPass {
     AU.addRequiredID(LoopSimplifyID);
     AU.addRequired<LoopInfoWrapperPass>();
     AU.addRequired<DominatorTreeWrapperPass>();
+    AU.addRequired<DependenceAnalysisWrapperPass>();
     AU.addRequired<ScalarEvolutionWrapperPass>();
     AU.addRequired<PostDominatorTreeWrapperPass>();
 
@@ -331,6 +332,7 @@ struct LoopFusion : public FunctionPass {
 
     auto &LI = getAnalysis<LoopInfoWrapperPass>().getLoopInfo();
     auto &DT = getAnalysis<DominatorTreeWrapperPass>().getDomTree();
+    auto &DI = getAnalysis<DependenceAnalysisWrapperPass>().getDI();
     auto &SE = getAnalysis<ScalarEvolutionWrapperPass>().getSE();
     auto &PDT = getAnalysis<PostDominatorTreeWrapperPass>().getPostDomTree();
 
@@ -368,8 +370,9 @@ struct LoopFusion : public FunctionPass {
       }
     }
 
-    if (CanFuseLoops(&FusionCandidates[0], &FusionCandidates[1], SE)) {
-      FuseLoops(&FusionCandidates[0], &FusionCandidates[1]);
+    if (CanFuseLoops(&FusionCandidates[1], &FusionCandidates[0], SE)) {
+      FuseLoops(&FusionCandidates[1], &FusionCandidates[0], F, LI, DT, PDT, DI,
+                SE);
     }
 
     return true;

--- a/LoopFusion/LoopFusion.cpp
+++ b/LoopFusion/LoopFusion.cpp
@@ -341,22 +341,11 @@ struct LoopFusion : public FunctionPass {
     // Collect fusion candidates.
     SmallVector<Loop *> FunctionLoops(LI.begin(), LI.end());
     for (const auto &L : FunctionLoops) {
-      dbgs() << "\nNumber of basic blocks: " << L->getNumBlocks() << "\n";
       auto Preheader = L->getLoopPreheader();
       auto Header = L->getHeader();
       auto ExitingBlock = L->getExitingBlock();
       auto ExitBlock = L->getExitBlock();
       auto Latch = L->getLoopLatch();
-      dbgs() << "\n"
-             << "\tPreheader: "
-             << (Preheader ? Preheader->getName() : "nullptr") << "\n"
-             << "\tHeader: " << (Header ? Header->getName() : "nullptr") << "\n"
-             << "\tExitingBB: "
-             << (ExitingBlock ? ExitingBlock->getName() : "nullptr") << "\n"
-             << "\tExitBB: " << (ExitBlock ? ExitBlock->getName() : "nullptr")
-             << "\n"
-             << "\tLatch: " << (Latch ? Latch->getName() : "nullptr") << "\n"
-             << "\n";
 
       dbgs() << "HAVE SAME TRIP COUNTS: "
              << HaveSameTripCounts(FunctionLoops[0], FunctionLoops[1]) << '\n';

--- a/LoopFusion/LoopFusion.cpp
+++ b/LoopFusion/LoopFusion.cpp
@@ -281,10 +281,6 @@ struct LoopFusion : public FunctionPass {
     // Removing Loop2 Preheader since it is empty now
     LI.removeBlock(L2->getPreheader());
 
-    SE.forgetLoop(L2->getLoop());
-    SE.forgetLoop(L1->getLoop());
-    SE.forgetLoopDispositions();
-
     // Recalculating Dominator and Post-Dominator Trees
     DT.recalculate(F);
     PDT.recalculate(F);
@@ -309,12 +305,14 @@ struct LoopFusion : public FunctionPass {
       L1->getLoop()->addBlockEntry(BB);
       L2->getLoop()->removeBlockFromLoop(BB);
 
+      // If BB is not a part of Loop2 that means that it was successfully moved
+      // otherwise we need to assign BB to Loop1 inside-of LoopInfo
       if (LI.getLoopFor(BB) != L2->getLoop())
         continue;
       LI.changeLoopFor(BB, L1->getLoop());
     }
 
-    // Remove the original loops from the LLVM IR.
+    // Remove the Loop2 from the LLVM IR
     EliminateUnreachableBlocks(F);
     LI.erase(L2->getLoop());
   }

--- a/README.md
+++ b/README.md
@@ -14,7 +14,4 @@ cd ..
 
 ## Run
 
-```shell
-clang -S -emit-llvm <filename>.cpp
-opt -load build/LoopFusion/libLoopFusion.so -loopfusion --enable-new-pm=0 -S <filename>.ll > /dev/null
-```
+Instructions on how to run the optimization is located inside `examples` directory.

--- a/examples/README.md
+++ b/examples/README.md
@@ -4,7 +4,12 @@
 
 Script `generate_ll_files.sh` will create `.ll` files for all of the `.cpp` files inside of this directory.
 
+Script `run_loop_fusion.sh` will run the optimization on all `.ll` files, then take the optimized `.ll` files,
+compile them, run them and write their outputs.
+
 ```shell
 $ chmod +x generate_ll_files.sh
+$ chmod +x run_loop_fusion.sh
 $ ./generate_ll_files.sh
+$ ./run_loop_fusion.sh
 ```

--- a/examples/generate_ll_files.sh
+++ b/examples/generate_ll_files.sh
@@ -7,5 +7,5 @@ for file in *.ll; do
 done
 
 for file in *.cpp; do
-  clang -S -emit-llvm -fno-discard-value-names $file
+  clang -S -emit-llvm -Xclang -disable-O0-optnone -fno-discard-value-names $file
 done

--- a/examples/run_loop_fusion.sh
+++ b/examples/run_loop_fusion.sh
@@ -7,6 +7,6 @@ for file in *.ll; do
   clang -c test.s -o test.o
   clang test.o -o test
   ./test
-  echo "OUTPUT for $file: $?"
+  printf "OUTPUT FOR $file: $?\n\n"
   rm -f $file test.s test.o test
 done

--- a/examples/run_loop_fusion.sh
+++ b/examples/run_loop_fusion.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+shopt -s nullglob
+for file in *.ll; do
+  opt -load ../build/LoopFusion/libLoopFusion.so -loopfusion -enable-new-pm=0 -S $file > "opt_$file"
+  llc "opt_$file" -o test.s
+  clang -c test.s -o test.o
+  clang test.o -o test
+  ./test
+  echo "OUTPUT for $file: $?"
+  rm -f $file test.s test.o test
+done

--- a/examples/test_fusable_2.cpp
+++ b/examples/test_fusable_2.cpp
@@ -12,5 +12,6 @@ int main() {
     result2 = arr[j] * j;
   }
 
+  // Should return 16
   return result2;
 }

--- a/examples/test_fusable_3.cpp
+++ b/examples/test_fusable_3.cpp
@@ -1,0 +1,39 @@
+const int N = 100;
+const int M = 100;
+
+int main() {
+  int p, j, k, l, s, g, r, a, b, c, d, e, f;
+  float q;
+  int A[N], B[M], C[N], D[M];
+
+  j = k = l = r = a = b = c = d = e = f = 0;
+  p = 4;
+  q = 0.0;
+
+  // Initialization
+  for (int i = 0; i < N; i++) {
+    A[i] = (i * 2) + (i - 6);
+    B[i] = (i * 3) + (6 - i);
+    C[i] = (i * 4) + (i + 2);
+    D[i] = (i * 5) + (i + 4);
+  }
+
+  for (int i = 0; i < N; i++) {
+    j += i + 2;
+    l += i * 3;
+    a += i + 2;
+    b += i - 2;
+    q = q + i;
+    p = p - i;
+    for (g = 0; g < M; g++) {
+      k += g - 4;
+      r += g * 2;
+      c += g + 6;
+    }
+    s = 0;
+    p += 5;
+    q -= 4;
+  }
+
+  return 0;
+}

--- a/examples/test_not_fusable_1.cpp
+++ b/examples/test_not_fusable_1.cpp
@@ -14,5 +14,6 @@ int main() {
     result2 += result1 + j;
   }
 
-  return 0;
+  // After fusion will return 30 which is not correct, the correct value is 60.
+  return result2;
 }

--- a/examples/test_not_fusable_3.cpp
+++ b/examples/test_not_fusable_3.cpp
@@ -8,13 +8,16 @@ int main() {
   int A[6] = {1, 2, 3, 4, 5, 6};
   int B[5] = {0};
 
+  // A = {2, 4, 6, 8, 10, 6}
   for (int i = 0; i < n; i++) {
     A[i] = A[i] * 2;
   }
 
+  // B = { 10, 16, 22, 28, 22}
   for (int j = 0; j < n; j++) {
     B[j] = A[j] + A[j + 1] * p;
   }
 
-  return 0;
+  // Correct output is 28, with loop fusion the output is 18.
+  return B[3];
 }

--- a/examples/test_not_fusable_4.cpp
+++ b/examples/test_not_fusable_4.cpp
@@ -1,0 +1,23 @@
+// Loops won't be fused, since the loops are not adjacent.
+int main() {
+  int A[100] = {0};
+  int B[100] = {0};
+  int n = 100;
+  int d = 0;
+
+  for (int i = 0; i < n; i++) {
+    A[i] = i;
+  }
+
+  if (n < 200) {
+    d = 1;
+  } else {
+    d++;
+  }
+
+  for (int i = 0; i < n; i++) {
+    B[i] = i * 2;
+  }
+
+  return 0;
+}


### PR DESCRIPTION
Initial implementation of the loop fusion algorithm that works on two fusion candidates. The algorithm follows the approach presented in [this presentation](https://llvm.org/devmtg/2018-10/slides/Barton-LoopFusion.pdf). The algorithm fuses two loops by redirecting the basic blocks to create one big loop. The algorithm also updates data-structures for Dominator, Post-Dominator Trees and ScalarEvolution analysis.

Control-flow graph before running loop fusion:
![Screenshot from 2023-09-22 17-23-23](https://github.com/ilija-s/loop-fusion/assets/46342896/6d49391d-51ce-41a1-b0dd-b4bd928678a5)

Control-flow graph after running loop fusion:
![Screenshot from 2023-09-22 17-23-49](https://github.com/ilija-s/loop-fusion/assets/46342896/2e2c3d36-9773-4c5a-9627-84ab24e93c72)

![image](https://github.com/ilija-s/loop-fusion/assets/46342896/0794283a-a119-4043-8d60-a1b89ecfbd5e)
