### PR TITLE
Feature/implement fusion candidate checks

### DIFF
--- a/LoopFusion/LoopFusion.cpp
+++ b/LoopFusion/LoopFusion.cpp
@@ -348,13 +348,15 @@ struct LoopFusion : public FunctionPass {
     // Collect fusion candidates.
     SmallVector<Loop *> FunctionLoops(LI.begin(), LI.end());
     for (const auto &L : FunctionLoops) {
-      if (!L->isLoopSimplifyForm()) {
-        dbgs() << "Loop " << L->getName() << " is not in simplified form\n";
-      }
       FusionCandidate FC(L);
       if (FC.isCandidateForFusion()) {
         FusionCandidates.emplace_back(FC);
       }
+    }
+
+    if (FusionCandidates.size() < 2) {
+      dbgs() << "Not enough candidates for fusion.\n";
+      return true;
     }
 
     dbgs() << "HAVE SAME TRIP COUNTS: "

--- a/examples/test_fusable_4.cpp
+++ b/examples/test_fusable_4.cpp
@@ -1,0 +1,25 @@
+// Loops will be fused, since both of them iterate from [0, n) and they
+// do not modify the same array.
+int main() {
+  int A[100] = {0};
+  int B[100] = {0};
+  int n = 100;
+
+  for (int i = 0; i < n; i++) {
+    if (i < n / 2) {
+      A[i] = i;
+    } else {
+      A[i] = i * 2;
+    }
+  }
+
+  for (int i = 0; i < n; i++) {
+    if (i < n / 2) {
+      B[i] = i * 2;
+    } else {
+      B[i] = ++i;
+    }
+  }
+
+  return B[99];
+}

--- a/examples/test_not_fusable_5.cpp
+++ b/examples/test_not_fusable_5.cpp
@@ -1,0 +1,19 @@
+// Loops won't be fused, since they use a shared iterator declared outside-of
+// the loops, thus merging them would result in incrementing the `i` two times
+// and breaking the program.
+int main() {
+  int A[100] = {0};
+  int B[100] = {0};
+  int n = 100;
+  int i;
+
+  for (i = 0; i < n; i++) {
+    A[i] = i;
+  }
+
+  for (i = 0; i < n; i++) {
+    B[i] = i * 2;
+  }
+
+  return 0;
+}

--- a/examples/test_not_fusable_6.cpp
+++ b/examples/test_not_fusable_6.cpp
@@ -1,0 +1,17 @@
+// Loops won't be fused, since the first loop contains volatile memory access.
+int main() {
+  int result1 = 0;
+  int result2 = 0;
+  volatile int value;
+
+  for (int i = 0; i < 5; i++) {
+    value++;
+    result1 += i;
+  }
+
+  for (int j = 0; j < 5; j++) {
+    result2 += result1 + j;
+  }
+
+  return result2;
+}


### PR DESCRIPTION
Added functionality for checking if the loop is a candidate for fusion, added checking if the loop contains volatile memory access, or may throw exception, added checking if the loop is in simplified form or if it is annotated parallel.